### PR TITLE
Update for PHP 8.4

### DIFF
--- a/src/CacheWarmer/DompdfFontLoaderCacheWarmer.php
+++ b/src/CacheWarmer/DompdfFontLoaderCacheWarmer.php
@@ -17,7 +17,7 @@ class DompdfFontLoaderCacheWarmer implements CacheWarmerInterface
         return true;
     }
 
-    public function warmUp(string $cacheDir, string $buildDir = null): array
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         if (!$this->isEnabled) {
             return [];


### PR DESCRIPTION
PHP 8.4: Implicitly nullable parameter declarations deprecated